### PR TITLE
Update app.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ var ajax = require('ajax');
 var Settings = require('settings');
 
 Settings.config(
-  {url: 'http://stephen-mitchell.github.io/PebbleHub/configurable_v0_1.html'},
+  {url: 'http://stephen-mitchell.github.io/PebHub/configurable_v0_1.html'},
   function(e)
   {
     console.log('opening configurable');


### PR DESCRIPTION
App authentication is broken because the repository was renamed from "PebbleHub" to "PebHub". This fixes.
