### PR TITLE
Update configurable.html to use new link

### DIFF
--- a/configurable.html
+++ b/configurable.html
@@ -31,7 +31,7 @@
     <div data-role="content">
       <div data-role="fieldcontain">
         <label for="githubAccessToken">GitHub Access Token:</label>
-        <p>Please log into your GitHub account in a web browser and navigate to the Settings/Navigation page (https://github.com/settings/applications). Generate a new Personal Access Token with default scopes, then copy and paste the long hex code into the box below.</p>
+        <p>Please log into your GitHub account in a web browser and navigate to the Settings/Tokens page (https://github.com/settings/tokens). Generate a new Personal Access Token with default scopes, then copy and paste the long hex code into the box below.</p>
         <p>Although this access method is less convenient than providing your username and password and having an Access Token automatically generated, it is designed to be more secure since you don't need to provide your GitHub access credentials to a third party. Personal Access Tokens can be revoked at any time with far less disruption than changing your account password.</p>
         <input type="text" name="githubAccessToken" id="githubAccessToken"></input>
       </div>


### PR DESCRIPTION
As tiny as this PR is, issue #5 shows that the change in links to GitHub personal access tokens has been known for some time. But the link in the app on the Pebble store is still outdated and may cause some confusion, so I've updated the link according to #5 's instructions.